### PR TITLE
Bump version and swap to new META file name

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -26,5 +26,5 @@
     "google-code-prettify/run_prettify.js"
   ],
   "source-url": "git://github.com/MARTIMM/pod-render.git",
-  "version": "v0.7.0"
+  "version": "v0.7.1"
 }


### PR DESCRIPTION
- I forgot to include version bump in yesterday's IO fix
- Also use META6.json for meta name; META.info is a legacy name