### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -7,7 +7,7 @@
     "Pod::To::Markdown"
   ],
   "description": "Render pod docs to html, pdf or md",
-  "license": "The Artistic License 2.0",
+  "license": "Artistic-2.0",
   "name": "Pod::Render",
   "perl": "6.c",
   "provides": {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license