### PR TITLE
Use run not shell for --md and --html. Use POSIX shell compatible redirection for error log for PDF

### DIFF
--- a/lib/Pod/Render.pm6
+++ b/lib/Pod/Render.pm6
@@ -78,7 +78,7 @@ class Pod::Render:auth<https://github.com/MARTIMM> {
     $pdf-file ~~ s/\. <-[.]>+ $/.pdf/;
 
     # send result to pdf generator
-    my Proc $p = shell "wkhtmltopdf - '$pdf-file' &>wkhtml2pdf.log", :in;
+    my Proc $p = shell "wkhtmltopdf - '$pdf-file' 2>&1 > wkhtml2pdf.log", :in;
 #    my Proc $p = shell "wkhtmltopdf - '$pdf-file'", :in, :out;
     $p.in.print($html);
 

--- a/lib/Pod/Render.pm6
+++ b/lib/Pod/Render.pm6
@@ -106,7 +106,8 @@ class Pod::Render:auth<https://github.com/MARTIMM> {
 
     $md-file ~~ s/\. <-[.]>+ $/.md/;
 
-    shell "perl6 --doc=Markdown " ~ $pod-file.IO.absolute ~ " > $md-file";
+    my $cmd = run "perl6", "--doc=Markdown", $pod-file.IO.absolute, :out;
+    $md-file.IO.spurt($cmd.out.slurp);
   }
 
   #-----------------------------------------------------------------------------

--- a/lib/Pod/Render.pm6
+++ b/lib/Pod/Render.pm6
@@ -125,7 +125,7 @@ class Pod::Render:auth<https://github.com/MARTIMM> {
     my Str $html = '';
 
     # Start translation process
-    my Proc $p = shell "perl6 --doc=HTML '$pod-file'", :out;
+    my Proc $p = run "perl6", "--doc=HTML", $pod-file, :out;
 
     # search for style line in the head and add a new one
     my @lines = $p.out.lines;


### PR DESCRIPTION
* Use `run` instead of `shell` so that MD conversions work to names with
spaces

* Before we used shell, and used shell piping to pipe it to the new file.
Previously just the supplied name was single quoted (this would break if
there were single quotes in the name), and the saved file was not quoted at
all, breaking it when spaces were in the name.

* This change also should hopefully work on Windows too, since Windows
doesn't have shell piping.


* I was not able to get this working with `run` instead of shell, but I have
at least made it use POSIX compatible shell redirection so it actually
functions for me.

* `&>` in POSIX shell means `& >` so it puts the program to the background which
is not what was wanted.


* Use run instead of shell for --html conversion too